### PR TITLE
Separate db_destination_name from dbname

### DIFF
--- a/dbdeployer
+++ b/dbdeployer
@@ -105,6 +105,11 @@ do
       skip_cli='-k'
       shift
       ;;
+    -n|--db-destination-name)
+      shift
+      _db_destination_name=${1}
+      shift
+      ;;
     -p|--port)
       shift
       port="${1}"
@@ -334,6 +339,14 @@ then
 	dbname="${_dbname}"
 fi
 
+#if -n exists, overwrite destination database name
+#otherwise default to using the dbname
+if ! [ -z "${_db_destination_name}" ]
+then
+	db_destination_name="${_db_destination_name}"
+else
+	db_destination_name="${dbname}"
+fi
 
 #deployments database should already exist even if it is empty, verify it does
 db_exists "${deployment_db}"
@@ -370,26 +383,15 @@ then
 		echo "You must specify the database you want to drop and reload (-d|--database)"
 		exit 1
 	fi
-  #check that dbname is not deployments database
-  if [ "${deployment_db}" = "${dbname}" ]
+  #check that dbname/db_destination_name is not deployments database
+  if [ "${deployment_db}" = "${dbname}" || "${deployment_db}" = "${db_destination_name}" ]
   then
     echo "You can not drop and reload the deployment tracking database"
     exit 1
   fi
 fi
 
-#check report has a database passed in
-if [ "${report}" = "true" ]
-then
-	#check database
-	if [ -z "${dbname}" ]
-	then
-		echo "You must specify the database you want to run a report against if you specify that a report be run (-r|--report)"
-		exit 1
-	fi
-fi
-
-#very that we have a database passed or calculated or exit
+#verify that we have a database passed or calculated or exit
 if [ -z "${dbname}" ]
 then
 	echo "A database name was not specified and could not be found by the file path specified.  Please add a"
@@ -471,6 +473,7 @@ then
     filename: ${filename}
     change_type: ${change_type}
     dbname: ${dbname}
+    db-destination-name: ${db_destination_name}
     report: ${report}
     port: ${port}
     dbuser: ${dbuser}
@@ -497,22 +500,22 @@ fi
 ###################################
 
 
-#check that database exists if dbname is defined and offer to create if its not
-if ! [ -z "${dbname}" ]
+#check that database exists if db_destination_name is defined and offer to create if its not
+if ! [ -z "${db_destination_name}" ]
 then
-  db_exists "${dbname}"
+  db_exists "${db_destination_name}"
 	if [ $? -ne 0 ]
   then
-		echo "${dbname} database does not exist, Do you want to create it?"
+		echo "${db_destination_name} database does not exist, Do you want to create it?"
 		if [ "${confirm}" = 'true' ]
 		then
 			echo "Confirm flag is set, creating automatically..."
-			create_database "${dbname}"
+			create_database "${db_destination_name}"
 		else
 
 			select yn in "Yes" "No"; do
 				case ${yn} in
-						Yes ) create_database "${dbname}"; break;;
+						Yes ) create_database "${db_destination_name}"; break;;
 						No ) exit;;
 				esac
 			done
@@ -611,24 +614,22 @@ then
 
   #confirm
   echo "This is a destructive change that WILL DROP THE EXISTING DATABASE!"
-  echo "Are you sure you want to continue?"
+  echo "Are you very sure you want to continue?"
   if [ "${confirm}" = 'true' ]
   then
     echo "Confirm flag is set, dropping database for reload..."
-    drop_and_reload ${dbname}
+    drop_and_reload "${dbname}" "${db_destination_name}"
   else
 
     select yn in "Yes" "No"; do
       case ${yn} in
-          Yes ) drop_and_reload ${dbname}; _DAR=$?; break;;
+          Yes ) drop_and_reload "${dbname}" "${db_destination_name}"; _DAR=$?; break;;
           No ) exit;;
       esac
     done
   fi # end confirm
 
-
-
- # drop_and_reload ${dbname}
+ # drop_and_reload "${dbname}" "${db_destination_name}"
   if [ "$_DAR" -ne 0 ]
   then
     echo "Something failed when trying to drop and reload the database"
@@ -656,7 +657,7 @@ then
   then
     state='SKIP'
   else
-    deploy_file "${file_path}" "${logfile}"
+    deploy_file "${db_destination_name}" "${file_path}" "${logfile}"
     rc=$?
     if [ ${rc} = 0 ]
     then
@@ -675,7 +676,7 @@ then
     fi
   fi
 
-  log_deployment "${dbname}" "${change_type}" "${filename}" "${state}"
+  log_deployment "${db_destination_name}" "${change_type}" "${filename}" "${state}"
   if [ $? -ne 0 ]
   then
     echo "Failed to log deployment, please manually log or mark as skipped to prevent redeployment"
@@ -693,7 +694,7 @@ fi
 #run the report to get what needs deployed and then deploy it
 if [ "${current}" = "true" ]
 then
-  update_db_to_current "${dbname}"
+  update_db_to_current "${dbname}" "${db_destination_name}"
   if [ $? -ne 0 ]
   then
     echo "One of the files did not deploy correctly.  No files past that file have been deployed"

--- a/dbtype/mssql/db_report_string.sh
+++ b/dbtype/mssql/db_report_string.sh
@@ -7,7 +7,7 @@ db_report_string() {
   then
     ${db_binary} -d ${deployment_db} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -b -Q "
     SET NOCOUNT ON;
-    SELECT '${db_basedir}/' + ${dbname} + '/' + deployment_type + '/' + deployment_name
+    SELECT '${db_basedir}/' + '${dbname}' + '/' + deployment_type + '/' + deployment_name
     FROM deployment_tracker
     WHERE dbname = '${db_destination_name}'
     AND isnull(is_active, 1)=1

--- a/dbtype/mssql/db_report_string.sh
+++ b/dbtype/mssql/db_report_string.sh
@@ -7,9 +7,9 @@ db_report_string() {
   then
     ${db_binary} -d ${deployment_db} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -b -Q "
     SET NOCOUNT ON;
-    SELECT '${db_basedir}/' + dbname + '/' + deployment_type + '/' + deployment_name
+    SELECT '${db_basedir}/' + ${dbname} + '/' + deployment_type + '/' + deployment_name
     FROM deployment_tracker
-    WHERE dbname = '${dbname}'
+    WHERE dbname = '${db_destination_name}'
     AND isnull(is_active, 1)=1
     AND deployment_type = '${_deployment_type}'
     AND deployment_outcome in ('OK','SKIP');" | sort -rn

--- a/dbtype/mssql/deploy_file.sh
+++ b/dbtype/mssql/deploy_file.sh
@@ -1,6 +1,7 @@
 function deploy_file() {
-  _deploy_file="${1}"
-  # ${2} is the name of log file, which is optional
+  _db_to_deploy="${1}"
+  _deploy_file="${2}"
+  # ${3} is the name of log file, which is optional
 
   #create a temp file to hold the concatenate of the pre_deploy, deploy and post_deploy files
 
@@ -9,7 +10,7 @@ function deploy_file() {
   tmpfile="/tmp/tmp_${filename}"
  
   echo "$(cat "${fn_basedir}"/dbtype/"${dbtype}"/pre_deploy.sql > "${tmpfile}")"
-  echo "$(cat "${_deploy_file}" | sed "s/\$(DBNAME)/${dbname}/g" >> "${tmpfile}")"
+  echo "$(cat "${_deploy_file}" | sed "s/\$(DBNAME)/${_db_to_deploy}/g" >> "${tmpfile}")"
 
   
  #Check if a procedure, if so add GO to the post_deploy
@@ -23,7 +24,8 @@ function deploy_file() {
 
   _date_start=$(date -u +"%s")
 
-  deploy_output=$(${db_binary} -d ${dbname} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -e -b -i "${tmpfile}")
+  deploy_output=$(${db_binary} -d ${_db_to_deploy} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -e -b -i "${tmpfile}")
+
   rc=$?
 
   _date_end=$(date -u +"%s")
@@ -43,11 +45,12 @@ function deploy_file() {
   then
     echo
     echo "File failed to deploy within a transaction.  This is most likely due to a bug in the Linux SQLCMD utility.  You can attempt to deploy the file manually using the following command";
-    echo ${db_binary} -d ${dbname} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -e -b -i "$_deploy_file"
+    echo ${db_binary} -d ${_db_to_deploy} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -e -b -i "$_deploy_file"
     rc=1
 
   fi
 
+  unset _db_to_deploy
   unset _deploy_file
 
   if [ ${rc} -eq 0 ]

--- a/dbtype/mssql/deployed_check.sh
+++ b/dbtype/mssql/deployed_check.sh
@@ -5,7 +5,7 @@ function deployed_check() {
   if [ $? -eq 0 ]
   then
 
-    if [ `${db_binary} -d ${deployment_db} -n ${db_destination_name} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -b -Q "SET NOCOUNT ON; select coalesce ((select count(*) from deployment_tracker t
+    if [ `${db_binary} -d ${deployment_db} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -b -Q "SET NOCOUNT ON; select coalesce ((select count(*) from deployment_tracker t
     where dbname = '${db_destination_name}'
     and ( deployment_outcome = 'OK' OR deployment_outcome = 'SKIP' )
     and deployment_type = '${change_type}'

--- a/dbtype/mssql/deployed_check.sh
+++ b/dbtype/mssql/deployed_check.sh
@@ -5,8 +5,8 @@ function deployed_check() {
   if [ $? -eq 0 ]
   then
 
-    if [ `${db_binary} -d ${deployment_db} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -b -Q "SET NOCOUNT ON; select coalesce ((select count(*) from deployment_tracker t
-    where dbname = '${dbname}'
+    if [ `${db_binary} -d ${deployment_db} -n ${db_destination_name} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -b -Q "SET NOCOUNT ON; select coalesce ((select count(*) from deployment_tracker t
+    where dbname = '${db_destination_name}'
     and ( deployment_outcome = 'OK' OR deployment_outcome = 'SKIP' )
     and deployment_type = '${change_type}'
     and deployment_name = '${filename}'

--- a/dbtype/mssql/drop_database.sh
+++ b/dbtype/mssql/drop_database.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 function drop_database() {
 
-  _dbname="$1"
+  _drop_dbname="$1"
 
   ${db_binary} -d ${deployment_db} ${server_flag}${port_flag} ${user_flag} ${password_flag} -Q "
-  ALTER DATABASE [${_dbname}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
-  DROP DATABASE [${_dbname}]; 
+  ALTER DATABASE [${_drop_dbname}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+  DROP DATABASE [${_drop_dbname}]; 
   " > /dev/null 2>&1
   if [ $? -ne 0 ] 
   then
     return 1
   fi
 
-  unset _dbname
+  unset _drop_dbname
   return 0
 }

--- a/dbtype/mssql/log_deployment.sh
+++ b/dbtype/mssql/log_deployment.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 function log_deployment() {
 
-
-  _deploy_db="$1"
+  _db_destination_name="$1"
   _change_type="$2"
   _filename="$3"
   _state="$4"
   _additional_fields=''
   _additonal_values=''
 
-  if [ "${_deploy_db}" != "${deployment_db}" ]
+  if [ "${_db_destination_name}" != "${deployment_db}" ]
   then
     _additional_fields=",
     deployed_by,
@@ -32,7 +31,7 @@ function log_deployment() {
   )
   values 
   ( 
-    '${_deploy_db}', 
+    '${_db_destination_name}', 
     '${_change_type}', 
     '${_filename}', 
     '${_state}'
@@ -44,6 +43,7 @@ function log_deployment() {
   rc=$?
 
   unset _deploy_db
+  unset _db_destination_name
   unset _change_type
   unset _filename
   unset _state

--- a/dbtype/mssql/show_deployments.sh
+++ b/dbtype/mssql/show_deployments.sh
@@ -2,7 +2,7 @@ function show_deployments() {
   echo "This deployment was already found in the database with an OK status."
   echo "Below are all deployments for this file.  Please investigate."
   ${db_binary} -d ${deployment_db} ${server_flag}${port_flag} ${user_flag} ${password_flag} -h -1 -b -Q "select * from deployment_tracker t
-  where dbname = '${dbname}'
+  where dbname = '${db_destination_name}'
   and ( deployment_outcome = 'OK' OR deployment_outcome = 'SKIP' )
   and deployment_type = '${change_type}'
   and deployment_name = '${filename}';"

--- a/dbtype/mssql/update_deployment_tracker.sh
+++ b/dbtype/mssql/update_deployment_tracker.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 function update_deployment_tracker() {
 
-  _dbname="$1"
+  _db_destination_name="$1"
 
   ${db_binary} -d ${deployment_db} ${server_flag}${port_flag} ${user_flag} ${password_flag} -b -Q "
   update deployment_tracker 
   set is_active = 0,
   updated_at = getdate()
-  where dbname = '${_dbname}'
+  where dbname = '${_db_destination_name}'
   and ISNULL(is_active,1) = 1
   ;"
 # > /dev/null 2>&1
   rc=$?
 
-  unset _dbname
+  unset _db_destination_name
 
   if [ ${rc} -eq 0 ] 
   then

--- a/dbtype/postgres/db_report_string.sh
+++ b/dbtype/postgres/db_report_string.sh
@@ -8,9 +8,9 @@ db_report_string() {
   then
   
     ${db_binary} ${deployment_db} ${server_flag} ${user_flag} ${port_flag} -1 -X -q -A -t -c "
-    SELECT CONCAT('${db_basedir}/',dbname,'/',deployment_type,'/',deployment_name) 
+    SELECT CONCAT('${db_basedir}/','${dbname}','/',deployment_type,'/',deployment_name) 
     FROM deployment_tracker 
-    WHERE dbname = '${dbname}' 
+    WHERE dbname = '${db_destination_name}' 
     AND deployment_type = '${_deployment_type}' 
     AND deployment_outcome in ('OK','SKIP')
     AND is_active is true;" | sort -rn

--- a/dbtype/postgres/deploy_file.sh
+++ b/dbtype/postgres/deploy_file.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 function deploy_file() {
-  _deploy_file="${1}"
-  if ! [ -z "${2}" ]
+  _db_to_deploy="${1}"
+  _deploy_file="${2}"
+  if ! [ -z "${3}" ]
   then 
-    _logfile="-L${2}"
+    _logfile="-L${3}"
   fi
 
-  ${db_binary} ${dbname} ${server_flag} ${user_flag} ${port_flag} -1 -X -v 'timing' -v 'ON_ERROR_STOP=1' -a -f "${_deploy_file}" "${_logfile}"
+  ${db_binary} ${_db_to_deploy} ${server_flag} ${user_flag} ${port_flag} -1 -X -v 'timing' -v 'ON_ERROR_STOP=1' -a -f "${_deploy_file}" "${_logfile}"
   rc=$?
 
+  unset _db_to_deploy
   unset _deploy_file
   unset _logfile
 

--- a/dbtype/postgres/deployed_check.sh
+++ b/dbtype/postgres/deployed_check.sh
@@ -8,7 +8,7 @@ function deployed_check() {
 
     if [ `${db_binary} ${deployment_db} ${server_flag} ${user_flag} ${port_flag} -1 -X -q -t -c "
     select coalesce ((select count(*) from deployment_tracker t
-    where dbname = '${dbname}' 
+    where dbname = '${db_destination_name}' 
     and ( deployment_outcome = 'OK' OR deployment_outcome = 'SKIP' )
     and deployment_type = '${change_type}'
     and deployment_name = '${filename}'

--- a/dbtype/postgres/drop_database.sh
+++ b/dbtype/postgres/drop_database.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 function drop_database() {
 
-  _dbname="$1"
+  _drop_dbname="$1"
 
   #postgres does not let you drop a database with active connections, so we must kill connections first
   ${db_binary} ${deployment_db} ${server_flag} ${user_flag} ${port_flag} -c "
-  select pg_terminate_backend(pid) from pg_stat_activity where datname = '${_dbname}';
+  select pg_terminate_backend(pid) from pg_stat_activity where datname = '${_drop_dbname}';
   " > /dev/null 2>&1
   if [ $? -ne 0 ] 
   then
@@ -13,13 +13,13 @@ function drop_database() {
   fi
 
   ${db_binary} ${deployment_db} ${server_flag} ${user_flag} ${port_flag} -c "
-  drop database \"${_dbname}\"; 
+  drop database \"${_drop_dbname}\"; 
   " > /dev/null 2>&1
   if [ $? -ne 0 ] 
   then
     return 1
   fi
 
-  unset _dbname
+  unset _drop_dbname
   return 0
 }

--- a/dbtype/postgres/log_deployment.sh
+++ b/dbtype/postgres/log_deployment.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 function log_deployment() {
 
-  _deploy_db="$1"
+  _db_destination_name="$1"
   _change_type="$2"
   _filename="$3"
   _state="$4"
   _additional_fields=''
   _additonal_values=''
 
-  if [ "${_deploy_db}" != "${deployment_db}" ]
+  if [ "${_db_destination_name}" != "${deployment_db}" ]
   then
     _additional_fields=",
     deployed_by,
@@ -31,7 +31,7 @@ function log_deployment() {
   )
   values 
   ( 
-    '${_deploy_db}', 
+    '${_db_destination_name}', 
     '${_change_type}', 
     '${_filename}', 
     '${_state}'
@@ -44,6 +44,7 @@ function log_deployment() {
   rc=$?
 
   unset _deploy_db
+  unset _db_destination_name
   unset _change_type
   unset _filename
   unset _state

--- a/dbtype/postgres/show_deployments.sh
+++ b/dbtype/postgres/show_deployments.sh
@@ -4,7 +4,7 @@ function show_deployments() {
   echo "Below are all deployments for this file.  Please investigate."
   ${db_binary} ${deployment_db} ${server_flag} ${user_flag} ${port_flag} -1 -X -q -c "
   select * from deployment_tracker t
-  where dbname = '${dbname}' 
+  where dbname = '${db_destination_name}' 
   and ( deployment_outcome = 'OK' OR deployment_outcome = 'SKIP' )
   and deployment_type = '${change_type}'
   and deployment_name = '${filename}';"

--- a/dbtype/postgres/update_deployment_tracker.sh
+++ b/dbtype/postgres/update_deployment_tracker.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 function update_deployment_tracker() {
 
-  _dbname="$1"
+  _db_destination_name="$1"
 
   ${db_binary} ${deployment_db} ${server_flag} ${user_flag} ${port_flag} -c "
   update deployment_tracker 
   set is_active = false,
   updated_at = now()
-  where dbname = '${_dbname}'
+  where dbname = '${_db_destination_name}'
   and is_active = true
   ;" > /dev/null 2>&1
   rc=$?
 
-  unset _dbname
+  unset _db_destination_name
 
   if [ ${rc} -eq 0 ] 
   then

--- a/functions/deployment_report.sh
+++ b/functions/deployment_report.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 deployment_report() {
-  echo "Running report for database: ${dbname}"
+  echo "Running report for database: ${db_destination_name}"
   IFS='|' read -a folder_list <<< "${deployment_folders}"
   for i in ${folder_list[@]}
   do
@@ -19,7 +19,7 @@ deployment_report() {
     do
       if ! [ -z "${x}" ]
       then
-        echo "${script_name} -f "${x}" ${run_as_user_flag} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli}"
+        echo "${script_name} -f "${x}" -n "${db_destination_name}" ${run_as_user_flag} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli}"
       fi
     done
   done

--- a/functions/drop_and_reload.sh
+++ b/functions/drop_and_reload.sh
@@ -2,28 +2,31 @@
 function drop_and_reload() {
 
   __dbname="$1"
-  drop_database "${__dbname}"
+  __db_destination_name="$2"
+
+  drop_database "${__db_destination_name}"
   if [ $? -ne 0 ] 
   then
     return 1
   fi
-  create_database "${__dbname}"
+  create_database "${__db_destination_name}"
   if [ $? -ne 0 ] 
   then
     return 1
   fi
-  update_deployment_tracker "${__dbname}"
+  update_deployment_tracker "${__db_destination_name}"
   if [ $? -ne 0 ] 
   then
     return 1
   fi
-  update_db_to_current "${__dbname}"
+  update_db_to_current "${__dbname}" "${__db_destination_name}"
   if [ $? -ne 0 ] 
   then
     return 1
   fi
 
-  unset _dbname
+  unset __dbname
+  unset __db_destination_name
   return 0
 
 }

--- a/functions/update_db_to_current.sh
+++ b/functions/update_db_to_current.sh
@@ -2,8 +2,9 @@
 function update_db_to_current() {
 
   _dbname="$1"
+  _db_destination_name="$2"
 
-  report_var=`${script_name} -D ${db_basedir} -r -d "${dbname}" ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} | grep "${script_name} -f"`
+  report_var=`${script_name} -D ${db_basedir} -r -d "${_dbname}" -n "${_db_destination_name}" ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} | grep "${script_name} -f"`
   IFS=$'\n'
   for j in `echo -e "${report_var}"`
   do
@@ -23,5 +24,6 @@ function update_db_to_current() {
 
 
   unset _dbname
+  unset _db_destination_name
   return 0
 }

--- a/functions/usage.sh
+++ b/functions/usage.sh
@@ -18,6 +18,10 @@ function usage() {
                                     still written to deployment_tracker
                                     (can be used if file was deployed by a
                                     different machanism)
+  -n|--db-destination-name [name] Deploy a database (-d) to a specific destination db,
+                                    useful for when the source name does not match the
+                                    final name of the database to be created.
+                                    ex. determinator -> determinator_test
   -p|--port [port]                Database port to connect on.  (requires -s|server
                                     to be specified)
   -P|--password [password]        Database password to use.  (requires -U|username


### PR DESCRIPTION
This uncouples the source database schema from the final database
instance name. This allows multiple copies of the same database to be
deployed on the same machine without naming conflicts. This is handy
when you want to run a test database alongside a development database.

/cc @cjestel 
