### PR TITLE
added ability to drop a database instead of only allowing drop and reload.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -27,7 +27,7 @@ dbtype='postgres'
 #In test environments it can be nice to drop the database and reload it to a
 #known good state. This is obviously dangerous in a production environment
 #so we have disabled that feature by default.
-allow_drop_and_reload='false'
+allow_drop_database='false'
 
 #This is the location where we should look for database folders.  The 
 #specified path out of the box is the recommended location, however it may

--- a/dbdeployer
+++ b/dbdeployer
@@ -174,6 +174,10 @@ do
       verbose='true'
       shift
       ;;
+    -x|--drop-database)
+      drop_db='true'
+      shift
+      ;;
     -X|--drop-and-reload)
       drop_reload='true'
       shift
@@ -376,18 +380,24 @@ then
 fi
 
 #check flags with drop and reload
-if [ "${drop_reload}" = "true" ]
+if [ "${drop_reload}" = 'true' ] || [ "${drop_db}" = 'true' ]
 then
   #is drop and reload allowed on this server
-  if [ "${allow_drop_and_reload}" != 'true' ]
+  if [ "${allow_drop_database}" != 'true' ]
   then
     echo "The configuration file has the option to allow drop and reload disabled, exiting"
+    exit 1
+  fi
+  #verify drop and reload and drop are not both specified
+  if [ "${drop_reload}" = 'true' ] && [ "${drop_db}" = 'true' ]
+  then
+    echo "You can not use the -x and the -X options together. The -X option encompases the drop option for dropping and reloading the database"
     exit 1
   fi
 	#check report
   if [ "${report}" = "true" ]
 	then
-		echo "The report flag is not compatible with the drop and reload flag."
+		echo "The report flag is not compatible with an option that drops the database."
 		exit 1
 	fi
   #check skip
@@ -405,7 +415,7 @@ then
   #check that dbname/db_destination_name is not deployments database
   if [ "${deployment_db}" = "${db_destination_name}" ]
   then
-    echo "You can not drop and reload the deployment tracking database"
+    echo "You can not drop the deployment tracking database with dbdeployer"
     exit 1
   fi
 fi
@@ -505,6 +515,7 @@ then
     confirm: ${confirm}
     skip: ${skip}
     drop-and-reload: ${drop_reload}
+    drop_database: ${drop_database}
     db_basedir: ${db_basedir}
     fn_basedir: ${fn_basedir}
     run_as: ${run_as}
@@ -641,7 +652,7 @@ then
 fi
 
 #already validated drop and reload, execute now
-if [ "${drop_reload}" = "true" ]
+if [ "${drop_reload}" = 'true' ]
 then
 
   #confirm
@@ -656,7 +667,10 @@ then
 
     select yn in "Yes" "No"; do
       case ${yn} in
-          Yes ) drop_and_reload "${dbname}" "${db_destination_name}"; _DAR=$?; break;;
+          Yes ) 
+            drop_and_reload "${dbname}" "${db_destination_name}"
+            _DAR=$?
+            break;;
           No ) exit;;
       esac
     done
@@ -665,6 +679,39 @@ then
   if [ "$_DAR" -ne 0 ]
   then
     echo "Something failed when trying to drop and reload the database"
+    exit 1
+  fi
+fi
+
+#already validated drop database, execute now
+if [ "${drop_db}" = 'true' ]
+then
+
+  #confirm
+  echo "This is a destructive change that WILL DROP THE EXISTING DATABASE ($db_destination_name)!"
+  echo "Are you very sure you want to continue?"
+  if [ "${confirm}" = 'true' ]
+  then
+    echo "Confirm flag is set, dropping database..."
+    drop_and_mark_database "${db_destination_name}"
+    _drop_database=$?
+  else
+
+    select yn in "Yes" "No"; do
+      case ${yn} in
+          Yes ) 
+            drop_and_mark_database "${db_destination_name}"
+            _drop_database=$?
+            echo "Dropping database ${db_destination_name}"
+            break;;
+          No ) exit;;
+      esac
+    done
+  fi # end confirm
+
+  if [ "${_drop_database}" -ne 0 ]
+  then
+    echo "Something failed when trying to drop the database. If the database is no longer present, you may need to manually mark all deployments for that database to false in the tracking database."
     exit 1
   fi
 fi

--- a/functions/drop_and_mark_database.sh
+++ b/functions/drop_and_mark_database.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+function drop_and_mark_database() {
+
+  __db_destination_name="$1"
+
+  drop_database "${__db_destination_name}"
+  if [ $? -ne 0 ] 
+  then
+    return 1
+  fi
+  update_deployment_tracker "${__db_destination_name}"
+  if [ $? -ne 0 ] 
+  then
+    return 1
+  fi
+
+  unset __db_destination_name
+  return 0
+
+}

--- a/functions/usage.sh
+++ b/functions/usage.sh
@@ -61,6 +61,7 @@ function usage() {
                                     (not compatible with -r|report flag)
                                     (not compatible with -k|skip flag) 
                                     (cannot be used with deployment tracking database)
+                                    (can optionally include the -n|--db-destination-name)
   -X|--drop-and-reload            No argument, please note this is a destructive change. 
                                     This will drop the database specified and will rebuild 
                                     from scripts in the same way a freshly stood up database 
@@ -69,6 +70,7 @@ function usage() {
                                     (not compatible with -r|report flag)
                                     (not compatible with -k|skip flag) 
                                     (cannot be used with deployment tracking database)
+                                    (can optionally include the -n|--db-destination-name)
   -h|--help                       Show this help message
   "
 }

--- a/functions/usage.sh
+++ b/functions/usage.sh
@@ -55,11 +55,17 @@ function usage() {
                                     and executes findings
   -v|--verbose                    No argument, shows what the variables are that
                                     are being used at time of deployment
+  -x|--drop-database              No argument, please not this is a desctructive change.
+                                    This will drop the database specified 
+                                    (requires -d|--database to be specified)
+                                    (not compatible with -r|report flag)
+                                    (not compatible with -k|skip flag) 
+                                    (cannot be used with deployment tracking database)
   -X|--drop-and-reload            No argument, please note this is a destructive change. 
                                     This will drop the database specified and will rebuild 
                                     from scripts in the same way a freshly stood up database 
                                     is deployed. Can be useful in dev/test environments
-                                    (requires -d flag)
+                                    (requires -d|--database to be specified)
                                     (not compatible with -r|report flag)
                                     (not compatible with -k|skip flag) 
                                     (cannot be used with deployment tracking database)

--- a/functions/usage.sh
+++ b/functions/usage.sh
@@ -55,7 +55,7 @@ function usage() {
                                     and executes findings
   -v|--verbose                    No argument, shows what the variables are that
                                     are being used at time of deployment
-  -x|--drop-database              No argument, please not this is a desctructive change.
+  -x|--drop-database              No argument, please note this is a desctructive change.
                                     This will drop the database specified 
                                     (requires -d|--database to be specified)
                                     (not compatible with -r|report flag)


### PR DESCRIPTION
This allows for dropping a database. Useful for dev or ci jobs. Disabled by default.

As part of this, it is changing the variable name that is used to check for whether drop and reload is allowed or not. Please take note of this as it is a breaking change to some configurations and may not cause expected behavior. 
