### PR TITLE
move log directory

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -7,10 +7,13 @@
 ###############################################################################
 
 #set the bash format of how you want your timestamps to appear in log files
-timestamp=$(date +%s)
+timestamp=$(date)
 
 #name of the database where deployments are tracked
 deployment_db='deployments'
+
+#log directory
+log_dir='/var/log/dbdeployer'
 
 #displays values that are used for most of the functions for troubleshooting
 verbose='false'

--- a/dbdeployer
+++ b/dbdeployer
@@ -596,37 +596,34 @@ then
   fi # end deployed_check
 fi # end file path exists check
 
-#don't log files for deployments db
-if [ "${dbname}" != "${deployment_db}" ]
+# verify log directories exists correctly
+full_log_dir="${log_dir}/${db_destination_name}"
+if test ! -d "${full_log_dir}"
 then
-  if test ! -d "${db_basedir}/${dbname}/${change_type}/output"
+  echo "output directory doesn't exist, creating..."
+  mkdir -p "${full_log_dir}"
+
+  if [ $? -ne 0 ]
   then
-    echo "output directory doesn't exist, creating..."
-    mkdir -p "${db_basedir}/${dbname}/${change_type}/output"
+    echo "failed to create output directory, exiting"
+    exit 1
+  fi
+fi
 
+#setup logfile variable
+logfile="${full_log_dir}/${filename}.out"
+if [ -f "${logfile}" ]
+then
 
-    if [ $? -ne 0 ]
-    then
-      echo "failed to create output directory, exiting"
-      exit 1
-    fi
+  if ! [ -z ${verbose} ]
+  then
+    echo "output file already exists, automatically appending to existing file"
   fi
 
-  #setup logfile variable
-  logfile="${db_basedir}/${dbname}/${change_type}/output/${filename}.out"
-  if [ -f "${logfile}" ]
+  if test ! -w "${logfile}"
   then
-
-    if ! [ -z ${verbose} ]
-    then
-      echo "output file already exists, automatically appending to existing file"
-    fi
-
-    if test ! -w "${logfile}"
-    then
-      echo "Could not write to log file ${logfile}, exiting"
-      exit 1
-    fi
+    echo "Could not write to log file ${logfile}, exiting"
+    exit 1
   fi
 fi
 
@@ -679,16 +676,12 @@ then
     file_checksum=`md5sum "${file_path}" | awk {'print $1'}`
   fi
 
-  #don't log deployments to file for deployments database
-  if [ "${deployment_db}" != "${dbname}" ]
-  then
-    log_header "${logfile}"
+  log_header "${logfile}"
 
-    if [ $? -ne 0 ]
-    then
-      echo "Unable to write to log file.  Check permissions on ${logfile}.  Exiting since we can't log."
-      exit 1
-    fi
+  if [ $? -ne 0 ]
+  then
+    echo "Unable to write to log file.  Check permissions on ${logfile}.  Exiting since we can't log."
+    exit 1
   fi
 
   if [ ${#variables_to_replace} -gt 0 ]
@@ -715,14 +708,10 @@ then
     fi
   fi
 
-  if [ "${deployment_db}" != "${dbname}" ]
+  log_footer "${logfile}" "${state}"
+  if [ $? -ne 0 ]
   then
-
-    log_footer "${logfile}" "${state}"
-    if [ $? -ne 0 ]
-    then
-      echo "WARNING: Unable to write footer to log file ${logfile}."
-    fi
+    echo "WARNING: Unable to write footer to log file ${logfile}."
   fi
 
   log_deployment "${db_destination_name}" "${change_type}" "${filename}" "${state}" "${file_checksum}" "${file_already_deployed}"

--- a/dbdeployer_install.sh
+++ b/dbdeployer_install.sh
@@ -10,6 +10,8 @@ config_base_dir='/etc'                                        #location to insta
 config_dir="${config_base_dir}/${package_name}"               #full path to config dir
 function_base_dir='/usr/libexec'                              #location to install functions dir
 function_dir="${function_base_dir}/${package_name}"           #full path to functions dir
+log_dir="/var/log/${package_name}"                            #default log location
+group_name='dbdeployer'                                       #name of the group (used for log file permission)
 
 
 
@@ -51,7 +53,7 @@ then
 fi
 
 #make necessary directories on filesystem
-for x in ${config_dir} ${function_dir} ${package_data_dir} ${package_database_dir}
+for x in ${config_dir} ${function_dir} ${package_data_dir} ${package_database_dir} ${log_dir}
 do
   if ! [ -d ${x} ]
   then
@@ -123,4 +125,33 @@ then
   exit 1
 fi #end error check
 
+#create group
+if [ `grep "${group_name}" /etc/group | wc -l` -eq 0 ]
+then
+  groupadd "${group_name}"
+  if [ $? -ne 0 ]
+  then
+    echo "Failed to add group to system, exiting"
+    exit 1
+  fi #end error check
+fi
 
+#set permissions on log_dir
+chown root:${group_name} ${log_dir}
+if [ $? -ne 0 ]
+then
+  echo "Failed to set ownership of log directory, exiting"
+  exit 1
+fi #end error check
+chmod 775 ${log_dir}
+if [ $? -ne 0 ]
+then
+  echo "Failed to set permission on log directory, exiting"
+  exit 1
+fi #end error check
+
+#installation is complete
+echo "Installation has completed successfully."
+
+#warn that they will have to add users to the dbdeployer group before deploying files
+echo "Please add any users that will be deploying files to the 'dbdeployer' group."

--- a/dbdeployer_install.sh
+++ b/dbdeployer_install.sh
@@ -155,3 +155,4 @@ echo "Installation has completed successfully."
 
 #warn that they will have to add users to the dbdeployer group before deploying files
 echo "Please add any users that will be deploying files to the 'dbdeployer' group."
+echo "Can be done with this command on RHEL systems: usermod -aG dbdeployer [username]"


### PR DESCRIPTION
This moves the log directory from the location where the databases are stored to /var/log/dbdeployer. This is good for a couple of reasons. It gets rid of the issue we had where we couldn't log the deployments database deployments. It also doesn't add files to our repos containing the migrations which can be a pain to deal with especially in dev environments where the files show up as new files to be added to version control.

The thing to note in particular with this PR is that it is creating a group for dbdeployer in the install file and that any users that are going to be deploying files need to be added to said group to have permissions to write to the folder. This seems like the best approach from a security standpoint as to not let any user on the box have the ability to edit or write files here but does add complexity to getting running with a fresh install. Notes have been added at the bottom of the installer with output denoting that users need added to the group.

I also removed the layer of folder that included the change type from the logs. This was intentional as it will be able to give us a clear picture of when a file is rolled back by looking at the deployment history all in a single file with one name for the migration.

I also had a minor edit to adjust the time to not be an actual timestamp as the logs are typically read by humans.
