### PR TITLE
create user if not exist

### DIFF
--- a/dbdeployer_install.sh
+++ b/dbdeployer_install.sh
@@ -11,6 +11,8 @@ config_dir="${config_base_dir}/${package_name}"               #full path to conf
 function_base_dir='/usr/libexec'                              #location to install functions dir
 function_dir="${function_base_dir}/${package_name}"           #full path to functions dir
 log_dir="/var/log/${package_name}"                            #default log location
+user_name='dbdeployer'                                        #name of user to deploy
+user_home_dir="$package_data_dir"                             #user home directory
 group_name='dbdeployer'                                       #name of the group (used for log file permission)
 
 
@@ -50,6 +52,17 @@ if [ ${error_state} = 'true' ]
 then
   echo "Errors were found in the pre-check, exiting"
   exit 1
+fi
+
+#create user
+if [ `grep "^${user_name}:" /etc/passwd | wc -l` -eq 0 ]
+then
+  useradd -r -g ${group_name} -m -d ${user_home_dir} ${user_name}
+  if [ $? -ne 0 ]
+  then
+    echo "Failed to add user ${user_name} to system, exiting"
+    exit 1
+  fi #end error check
 fi
 
 #make necessary directories on filesystem
@@ -124,17 +137,6 @@ then
   echo "Failed to copy deployments directory, exiting"
   exit 1
 fi #end error check
-
-#create group
-if [ `grep "${group_name}" /etc/group | wc -l` -eq 0 ]
-then
-  groupadd "${group_name}"
-  if [ $? -ne 0 ]
-  then
-    echo "Failed to add group to system, exiting"
-    exit 1
-  fi #end error check
-fi
 
 #set permissions on log_dir
 chown root:${group_name} ${log_dir}


### PR DESCRIPTION
We decided we wanted a centralized system user to deploy things from so we added this system user. The permissions for the group also allow for writes to the log file location.
