### PR TITLE
Add Dockerfile to facilitate running from container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-#FROM registry.cmmint.net/cmm/centos7:latest
 FROM centos:7
 ENV  ACCEPT_EULA 'y'
 ENV PATH /opt/mssql-tools/bin/:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+#FROM registry.cmmint.net/cmm/centos7:latest
+FROM centos:7
+ENV  ACCEPT_EULA 'y'
+ENV PATH /opt/mssql-tools/bin/:$PATH
+ADD . /
+RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/msprod.repo && \
+    yum -y update && \
+    yum -y install mssql-tools unixODBC-devel && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN /dbdeployer_install.sh
+ENTRYPOINT ["dbdeployer"]


### PR DESCRIPTION
Add Dockerfile so this can be run in a container allowing for some portability. Arguments to dbdeployer can be passed directly to the container once built. 