### PR TITLE
Add psql to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV PATH /opt/mssql-tools/bin/:$PATH
 ADD . /
 RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/msprod.repo && \
     yum -y update && \
-    yum -y install mssql-tools unixODBC-devel && \
+    yum -y install mssql-tools unixODBC-devel postgresql && \
     yum clean all && \
     rm -rf /var/cache/yum
 RUN /dbdeployer_install.sh


### PR DESCRIPTION
This makes the psql binary available.  I'm looking to use this image for postgres dbdeployer tasks and it appears to be required. 