### PR TITLE
Fixes related to postgres host support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM centos:7
-ENV  ACCEPT_EULA 'y'
+
+ENV ACCEPT_EULA 'y'
 ENV PATH /opt/mssql-tools/bin/:$PATH
-ADD . /
+
 RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/msprod.repo && \
     yum -y update && \
-    yum -y install mssql-tools unixODBC-devel && \
+    yum -y install mssql-tools unixODBC-devel postgresql && \
     yum clean all && \
     rm -rf /var/cache/yum
-RUN /dbdeployer_install.sh
-ENTRYPOINT ["dbdeployer"]
+
+RUN mkdir /app
+ADD . /app
+RUN /app/dbdeployer_install.sh
+
+ENTRYPOINT ["/usr/bin/dbdeployer"]

--- a/dbdeployer
+++ b/dbdeployer
@@ -275,7 +275,7 @@ then
     exit 1
   fi
 
-  IFS='/' file_array=(${file_path})
+  IFS='/' read -ra file_array <<< "$file_path"
   array_count=`echo ${#file_array[@]}`
   if [ ${array_count} -gt 2 ]
   then

--- a/dbdeployer
+++ b/dbdeployer
@@ -3,7 +3,7 @@
 #script needs at a minimum 1 parameter, if less than that are passed, show usage
 if [ $# -eq 0 ]
 then
-	show_help='true'
+  show_help='true'
 fi
 
 #seting up autoloader function that isn't included in directories that are auto-loaded
@@ -358,11 +358,11 @@ then
     exit 1
   fi
 
-	check_server_port
-	if [ $? -ne 0 ]
-	then
-		exit 1
-	fi
+  check_server_port
+  if [ $? -ne 0 ]
+  then
+    exit 1
+  fi
 
   set_port_flags
 fi
@@ -370,14 +370,14 @@ fi
 #if -d exists, overwrite database name
 if ! [ -z "${_dbname}" ]
 then
-	dbname="${_dbname}"
+  dbname="${_dbname}"
 fi
 
 #if -n exists, overwrite destination database name
 #otherwise default to using the dbname
 if [ -z "${db_destination_name}" ]
 then
-	db_destination_name="${dbname}"
+  db_destination_name="${dbname}"
 fi
 
 #deployments database should already exist even if it is empty, verify it does
@@ -403,12 +403,12 @@ then
     echo "You can not use the -x and the -X options together. The -X option encompases the drop option for dropping and reloading the database"
     exit 1
   fi
-	#check report
+  #check report
   if [ "${report}" = "true" ]
-	then
-		echo "The report flag is not compatible with an option that drops the database."
-		exit 1
-	fi
+  then
+    echo "The report flag is not compatible with an option that drops the database."
+    exit 1
+  fi
   #check skip
   if [ "${skip}" = "true" ]
   then
@@ -416,11 +416,11 @@ then
     exit 1
   fi
   #check that dbname is set
-	if [ -z "${dbname}" ]
-	then
-		echo "You must specify the database you want to drop and reload (-d|--database)"
-		exit 1
-	fi
+  if [ -z "${dbname}" ]
+  then
+    echo "You must specify the database you want to drop and reload (-d|--database)"
+    exit 1
+  fi
   #check that dbname/db_destination_name is not deployments database
   if [ "${deployment_db}" = "${db_destination_name}" ]
   then
@@ -432,9 +432,9 @@ fi
 #verify that we have a database passed or calculated or exit
 if [ -z "${dbname}" ]
 then
-	echo "A database name was not specified and could not be found by the file path specified.  Please add a"
-	echo "database declaration or file to the command so we know what to deploy."
-	exit 1
+  echo "A database name was not specified and could not be found by the file path specified.  Please add a"
+  echo "database declaration or file to the command so we know what to deploy."
+  exit 1
 fi
 
 
@@ -501,9 +501,9 @@ fi
 #checks verbosity
 if ! [ -z ${verbose} ]
 then
-	if [ "${verbose}" = 'true' ]
-	then
-		echo "
+  if [ "${verbose}" = 'true' ]
+  then
+    echo "
     file_dir: ${file_dir}
     file_path_dirs: ${file_path_dirs}
     array_count: ${array_count}
@@ -532,7 +532,7 @@ then
     deployed_as: ${deployed_as}
     calculate_checksum: ${calculate_checksum}
     "
-	fi
+  fi
 fi
 
 ###################################
@@ -552,24 +552,24 @@ fi
 if ! [ -z "${db_destination_name}" ]
 then
   db_exists "${db_destination_name}"
-	if [ $? -ne 0 ]
+  if [ $? -ne 0 ]
   then
-		echo "${db_destination_name} database does not exist, Do you want to create it?"
-		if [ "${confirm}" = 'true' ]
-		then
-			echo "Confirm flag is set, creating automatically..."
-			create_database "${db_destination_name}"
-		else
+    echo "${db_destination_name} database does not exist, Do you want to create it?"
+    if [ "${confirm}" = 'true' ]
+    then
+      echo "Confirm flag is set, creating automatically..."
+      create_database "${db_destination_name}"
+    else
 
-			select yn in "Yes" "No"; do
-				case ${yn} in
-						Yes ) create_database "${db_destination_name}"; break;;
-						No ) exit;;
-				esac
-			done
-		fi # end confirm
+      select yn in "Yes" "No"; do
+        case ${yn} in
+          Yes ) create_database "${db_destination_name}"; break;;
+          No ) exit;;
+        esac
+      done
+    fi # end confirm
 
-	fi # end database exists
+  fi # end database exists
 fi # end variable empty check
 
 #check that the file filepath is set and that the file exists
@@ -673,7 +673,7 @@ then
 
     select yn in "Yes" "No"; do
       case ${yn} in
-          Yes ) 
+          Yes )
             drop_and_reload "${dbname}" "${db_destination_name}"
             _DAR=$?
             break;;
@@ -705,7 +705,7 @@ then
 
     select yn in "Yes" "No"; do
       case ${yn} in
-          Yes ) 
+          Yes )
             drop_and_mark_database "${db_destination_name}"
             _drop_database=$?
             echo "Dropping database ${db_destination_name}"
@@ -725,7 +725,7 @@ fi
 #already validated all filepath stuff, execute query
 if ! [ -z "${file_path}" ]
 then
-  
+
   # set checksum value for file unless disabled
   if [ "${calculate_checksum}" != "false" ]
   then

--- a/dbtype/postgres/db_exists.sh
+++ b/dbtype/postgres/db_exists.sh
@@ -6,14 +6,14 @@ function db_exists() {
   rc=$?
   if [ $rc -eq 0 ]
   then
-# the below way should work if you are just listing databases but is more intense than using system tables
-# I commented this out and left in place in the event another engine needs to utilize this method
-#    if [ `${db_binary} ${server_flag} ${user_flag} ${port_flag} -1 -X -q -t -c '\l' | \
-#    awk -F'|' {'print $1'} | \
-#    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | \
-#    grep "^${_check_db}$" | \
-#    wc -l | \
-#    xargs` -eq 1 ]
+    # the below way should work if you are just listing databases but is more intense than using system tables
+    # I commented this out and left in place in the event another engine needs to utilize this method
+    #    if [ `${db_binary} ${server_flag} ${user_flag} ${port_flag} -1 -X -q -t -c '\l' | \
+    #    awk -F'|' {'print $1'} | \
+    #    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | \
+    #    grep "^${_check_db}$" | \
+    #    wc -l | \
+    #    xargs` -eq 1 ]
 
     query_output=`${switch_user_flag} ${db_binary} ${server_flag} ${user_flag} ${port_flag} -1 -X -q -t -c "
     select coalesce ((SELECT count(datname)
@@ -30,7 +30,7 @@ function db_exists() {
   else
     rc=1
   fi
-  
+
   unset _check_db
 
   if [ ${rc} -eq 0 ]

--- a/functions/setup_module_source_list.sh
+++ b/functions/setup_module_source_list.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 function setup_module_source_list() {
 
-  old_IFS=$IFS
-
-  IFS=','
+  local IFS=','
   local module_dir_array=(${module_list})
   local module_array_count=`echo ${#module_dir_array[@]}`
 
@@ -25,6 +23,5 @@ function setup_module_source_list() {
       fi
     done
   fi
-  IFS=${old_IFS}
 
 }

--- a/functions/update_db_to_current.sh
+++ b/functions/update_db_to_current.sh
@@ -5,7 +5,7 @@ function update_db_to_current() {
   _db_destination_name="$2"
 
   report_var=`${script_name} -D ${db_basedir} -r -d "${_dbname}" -n "${_db_destination_name}" ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${module_list_cli} | grep "${script_name} -f"`
-  IFS=$'\n'
+  local IFS=$'\n'
   for j in `echo -e "${report_var}"`
   do
     echo "Running: ${j}"


### PR DESCRIPTION
Real change is in d25e5f674f110502894457f5548e6d23f1b76795, the rest is whitespace noise.

`IFS` was coming into the `db_exists` function with the value `/` which was fouling up the parsing and giving the error `psql: could not translate host name " postgres" to address: Name or service not known` (connecting to a docker container named `postgres`).  Main culprit was https://github.com/covermymeds/dbdeployer/commit/d25e5f674f110502894457f5548e6d23f1b76795#diff-1da8e68a5ee79d65cbc7360f59701a23L278 but the other changes seem sensible.


