### PR TITLE
enable remote deploy for postgres

### DIFF
--- a/dbdeployer
+++ b/dbdeployer
@@ -97,6 +97,10 @@ do
       db_basedir=${1}
       shift
       ;;
+    --disable-ping-check)
+      export disable_ping_check='true'
+      shift
+      ;;
     -e|--environment)
       shift
       environment=${1}
@@ -316,14 +320,17 @@ then
   fi
 fi
 
-
-#check that host/server responds to pings
+#check that host/server responds to pings unless check is disabled
 if ! [ -z "${server}" ]
 then
-  check_server_ping
-  if [ $? -ne 0 ]
+  if ! [ "${disable_ping_check}" = 'true' ]
   then
-    exit 1
+    echo "Checking Server Responds to PING"
+    check_server_ping
+    if [ $? -ne 0 ]
+    then
+      exit 1
+    fi
   fi
   set_server_flags
 fi

--- a/dbtype/postgres/create_database.sh
+++ b/dbtype/postgres/create_database.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 function create_database() {
   _createdb="${1}"
-  ${db_binary} ${server_flag} ${user_flag} ${port_flag} -c "create database \"${_createdb}\";"
+  ${db_binary} ${server_flag} ${user_flag} ${port_flag} -d postgres -c "create database \"${_createdb}\";"
   rc=$?
   unset _createdb
   if [ ${rc} -eq 0 ]

--- a/dbtype/postgres/db_exists.sh
+++ b/dbtype/postgres/db_exists.sh
@@ -15,7 +15,7 @@ function db_exists() {
     #    wc -l | \
     #    xargs` -eq 1 ]
 
-    query_output=`${switch_user_flag} ${db_binary} ${server_flag} ${user_flag} ${port_flag} -1 -X -q -t -c "
+    query_output=`${switch_user_flag} ${db_binary} ${server_flag} ${user_flag} ${port_flag} -1 -X -q -t -d postgres -c "
     select coalesce ((SELECT count(datname)
     FROM pg_database
     where datname= '${_check_db}'

--- a/dbtype/postgres/set_password_flags.sh
+++ b/dbtype/postgres/set_password_flags.sh
@@ -1,4 +1,4 @@
 function set_password_flags() {
-  echo "PGPASSWORD: ${PGPASSWORD}"
+  PGPASSWORD=${password}
   return 0
 }

--- a/dbtype/postgres/set_password_flags.sh
+++ b/dbtype/postgres/set_password_flags.sh
@@ -1,4 +1,4 @@
 function set_password_flags() {
-  PGPASSWORD=${password}
+  export PGPASSWORD=${password}
   return 0
 }

--- a/dbtype/postgres/set_password_flags.sh
+++ b/dbtype/postgres/set_password_flags.sh
@@ -1,0 +1,5 @@
+function set_password_flags() {
+  PGPASSWORD=${password}
+  echo "PGPASSWORD: ${PGPASSWORD}"
+  return 0
+}

--- a/dbtype/postgres/set_password_flags.sh
+++ b/dbtype/postgres/set_password_flags.sh
@@ -1,5 +1,4 @@
 function set_password_flags() {
-  PGPASSWORD=${password}
   echo "PGPASSWORD: ${PGPASSWORD}"
   return 0
 }

--- a/dbtype/postgres/set_server_flags.sh
+++ b/dbtype/postgres/set_server_flags.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 function set_server_flags() {
-  server_flag="-h ${server}"
+  export server_flag="-h ${server}"
   return 0
 }

--- a/functions/update_db_to_current.sh
+++ b/functions/update_db_to_current.sh
@@ -4,6 +4,8 @@ function update_db_to_current() {
   _dbname="$1"
   _db_destination_name="$2"
 
+  #echo "report_var executes: ${script_name} -D ${db_basedir} -r -d \"${_dbname}\" -n \"${_db_destination_name}\" ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${module_list_cli} | grep \"${script_name} -f\""
+
   report_var=`${script_name} -D ${db_basedir} -r -d "${_dbname}" -n "${_db_destination_name}" ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${module_list_cli} | grep "${script_name} -f"`
   local IFS=$'\n'
   for j in `echo -e "${report_var}"`

--- a/functions/usage.sh
+++ b/functions/usage.sh
@@ -10,6 +10,9 @@ function usage() {
   -c|--confirm                    No arguments, automatically confirms choices 
                                     without user interaction
   -C|--checksum-off               No arguments, turns off checksum logging
+  
+  --disable-ping-check            No arguments, turns off ping check when server
+                                    flag is in use
   -d|--database [name]            Database name to work with (will attempt to 
                                     auto-discover if -f is used, but can be 
                                     overwritten by using this variable)


### PR DESCRIPTION
This was tested against Azure SaaS Postgres Platform. The Azure service does not allow ICMP traffic to the db server, so I had to add an option to disable ping checks when using the server flag.

Additionally, since we are not using the socket with the postgres user, I had to specify the default database to connect to. I don't think this needs to be a variable but if anyone has issues with it, we can create and load a `set_db_specific_options` file that would apply to each dbtype and allow us to pass in the extra bits.