### PR TITLE
adjust for bug in report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2019-01-09 Relase 1.4.2
+### Summary
+Auto deploy folder bug fix
+
+### Changes
+  - Fix pathing issue when using auto deploy folders
+
 ## 2018-09-24 Relase 1.4.1
 ### Summary
 Encryption, Remote Deploy, code cleanup

--- a/config.sh
+++ b/config.sh
@@ -53,6 +53,7 @@ module_list=
 
 #this variable will force the client to use encryption or fail
 force_encryption='false'
+
 #user to make sure the script is being run as
 run_as='postgres'
 

--- a/dbdeployer_release
+++ b/dbdeployer_release
@@ -1,1 +1,1 @@
-version=1.4.1
+version=1.4.2

--- a/plugins/git/deployment_report.sh
+++ b/plugins/git/deployment_report.sh
@@ -74,17 +74,25 @@ deployment_report() {
             if [ "`git rev-parse --abbrev-ref --symbolic-full-name @{u}`" = "${branch_to_compare}" ]
             then
               FS_LIST=`eval "ls -o1 "${deploy_folder}"/*.sql | awk {'print ${deployment_report_argnum}'} | sort -rn | xargs"`
+
+              for j in ${FS_LIST}
+              do
+                # echo "file: $j"
+                FS_CHECKSUM=`md5sum "${j}" | awk {'print $1'}`
+                # echo "FS_CHECKSUM: $FS_CHECKSUM"
+                FS=`echo -e "${FS}\n$j--dbdeployer-md5sum--$FS_CHECKSUM"`
+              done
             else
               FS_LIST=`eval "git diff --name-only ${branch_to_compare} | grep \"^${dbname}/${i}/\" | grep '.sql' | xargs"`
+              for j in ${FS_LIST}
+              do
+                # echo "file: $j"
+                FS_CHECKSUM=`md5sum "${j}" | awk {'print $1'}`
+                # echo "FS_CHECKSUM: $FS_CHECKSUM"
+                FS=`echo -e "${FS}\n${db_basedir}/$j--dbdeployer-md5sum--$FS_CHECKSUM"`
+              done
             fi
 
-            for j in ${FS_LIST}
-            do
-              # echo "file: $j"
-              FS_CHECKSUM=`md5sum "${j}" | awk {'print $1'}`
-              # echo "FS_CHECKSUM: $FS_CHECKSUM"
-              FS=`echo -e "${FS}\n$j--dbdeployer-md5sum--$FS_CHECKSUM"`
-            done
 
           else
             FS=''


### PR DESCRIPTION
The full path was not available which is required when running from a branch. This corrects that. This can be merged prior to rollout as it only impacts things that are using the module/plugin, which is currently nothing.