### PR TITLE
bug fix git plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2019-02-12 Release 1.5.3
+### Summary
+Bug Fix
+
+### Changes
+  - Fix bug in git plugin allowing for proper execution of environment folders
+
 ## 2019-02-08 Release 1.5.2
 ### Summary
 Add git binary to image and add version flag

--- a/plugins/git/deployment_report.sh
+++ b/plugins/git/deployment_report.sh
@@ -25,7 +25,7 @@ deployment_report() {
         # on master, compare from file system
         FS=`eval "ls -o1 "${db_basedir}"/"${dbname}"/"${i}"/*.sql | awk {'print ${deployment_report_argnum}'} | sort -rn"`
       else
-        diff_files=`eval "git diff --name-only ${branch_to_compare} | grep \"^${dbname}/${i}/\" | grep '.sql' | xargs"`
+        diff_files=`eval "git diff --name-only ${branch_to_compare} | grep \"^${dbname}/${i}/[^/]*\.sql$\" | xargs"`
 
         #echo "diff_file: ${diff_files}"
 


### PR DESCRIPTION
The git plugin did not allow override folders to parse correctly. This explicitly looks in the folder location for .sql files instead of all files in the PR