### PR TITLE
Remove this unnecessary comment

### DIFF
--- a/deployments/schema/postgres/1000_schema.sql
+++ b/deployments/schema/postgres/1000_schema.sql
@@ -7,10 +7,6 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
 
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
-
 
 CREATE FUNCTION update_updated_at_column() RETURNS trigger
     LANGUAGE plpgsql


### PR DESCRIPTION
It causes errors when run from a non-superuser and isnt necessary

The common solution for running pg_dump-generated files on cloud setups is
to simply omit this line:

https://stackoverflow.com/questions/13410631/how-to-solve-privileges-issues-when-restore-postgresql-database

https://www.postgresql.org/message-id/E1VuYH7-0008Rz-SV@wrigleys.postgresql.org

It doesnt seem necessary for us at all, so lets just remove it