### PR TITLE
Adjust a comment line that prevents cloud from deploying

### DIFF
--- a/deployments/schema/postgres/1000_schema.sql
+++ b/deployments/schema/postgres/1000_schema.sql
@@ -7,11 +7,6 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
 
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
-
-
 CREATE FUNCTION update_updated_at_column() RETURNS trigger
     LANGUAGE plpgsql
     AS $$


### PR DESCRIPTION
This is automatically generated by pg_dump and is not necessary in local full deployment environments, yet it is preventing some cloud services from being able to deploy the file due to differences in permissions.