### PR TITLE
Fix bug that shows files merged to master but not in feature branch

### DIFF
--- a/plugins/git/deployment_report.sh
+++ b/plugins/git/deployment_report.sh
@@ -25,7 +25,7 @@ deployment_report() {
         # on master, compare from file system
         FS=`eval "ls -o1 "${db_basedir}"/"${dbname}"/"${i}"/*.sql | awk {'print ${deployment_report_argnum}'} | sort -rn"`
       else
-        diff_files=`eval "git diff --name-only ${branch_to_compare} | grep \"^${dbname}/${i}/[^/]*\.sql$\" | xargs"`
+        diff_files=`git diff --name-status ${branch_to_compare} | grep -E '^A|^M' | awk {'print \$2'} | grep "^${dbname}/${i}/[^/]*\.sql$" | xargs`
 
         #echo "diff_file: ${diff_files}"
 


### PR DESCRIPTION
This file is located in `/usr/libexec/dbdeployer/plugins/git/deployment_report.sh`. 