### PR TITLE
Add --check-pending to give exit status 0/1 depending on whether or not there are pending migrations

### DIFF
--- a/dbdeployer
+++ b/dbdeployer
@@ -87,6 +87,11 @@ do
       auto_deploy_folders_enabled='true'
       shift
       ;;
+    --check-pending)
+      check_pending='true'
+      report='true'
+      shift
+      ;;
     -c|--confirm)
       confirm='true'
       shift
@@ -706,6 +711,15 @@ fi
 if [ "${report}" == 'true' ]
 then
   deployment_report
+  if [ "${check_pending}" == 'true' ]
+  then
+    if [ "$pending_count" -gt 0 ];
+    then
+      exit 1
+    else
+      exit 0
+    fi
+  fi
 fi
 
 #already validated drop and reload, execute now

--- a/functions/deployment_report.sh
+++ b/functions/deployment_report.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 deployment_report() {
+  pending_count=0
   #standard deploy folders
   echo "Running report for database: ${db_destination_name}"
   IFS=':|' read -a folder_list <<< "${deployment_folders}"
@@ -21,6 +22,7 @@ deployment_report() {
       if ! [ -z "${x}" ]
       then
         echo "${script_name} -f "${x}" -n "${db_destination_name}" ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli}"
+        let "pending_count++"
       fi
     done
   done
@@ -69,6 +71,7 @@ deployment_report() {
             then
               auto_deploy_file=`echo ${x} | awk -F '--dbdeployer-md5sum--' {'print $1'}`
               echo "${script_name} -f "${auto_deploy_file}" -c -n "${db_destination_name}" ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli}"
+              let "pending_count++"
             fi
           done
         fi #end directory exists check

--- a/functions/usage.sh
+++ b/functions/usage.sh
@@ -14,6 +14,8 @@ ${script_name} [options]
   -c|--confirm                    No arguments, automatically confirms choices 
                                     without user interaction
   -C|--checksum-off               No arguments, turns off checksum logging
+  --check-pending                 No arguments, enables --report and exits with
+                                    0 = no pending migrations, 1 = pending migrations
   --disable-modules               No arguments, turns off any modules/plugins from
                                     being loaded
   --disable-ping-check            No arguments, turns off ping check when server

--- a/plugins/git/deployment_report.sh
+++ b/plugins/git/deployment_report.sh
@@ -5,6 +5,7 @@ unset deployment_report
 branch_to_compare="${branch_to_compare:-origin/master}"
 
 deployment_report() {
+  pending_count=0
   #standard deploy folders
   echo "Running report for database: ${db_destination_name}"
   IFS=':|' read -a folder_list <<< "${deployment_folders}"
@@ -49,6 +50,7 @@ deployment_report() {
       if ! [ -z "${x}" ]
       then
         echo "${script_name} -f "${x}" -n "${db_destination_name}" ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli}"
+        let "pending_count++"
       fi
     done
   done
@@ -112,6 +114,7 @@ deployment_report() {
             then
               auto_deploy_file=`echo ${x} | awk -F '--dbdeployer-md5sum--' {'print $1'}`
               echo "${script_name} -f "${auto_deploy_file}" -c -n "${db_destination_name}" ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli}"
+              let "pending_count++"
             fi
           done
         fi #end directory exists check


### PR DESCRIPTION
This is to allow me to run something like `dbdeployer -d rx_service --check-pending || { echo "The database is not up to date, abort" ; exit 1 ; }`