### PR TITLE
evaluate override file checksum on auto deploy folders

### DIFF
--- a/functions/deployment_report.sh
+++ b/functions/deployment_report.sh
@@ -50,10 +50,21 @@ deployment_report() {
             FS_LIST=`eval "ls -o1 "${deploy_folder}"/*.sql | awk {'print ${deployment_report_argnum}'} | sort -rn | xargs"`
             for j in ${FS_LIST}
             do
-  #            echo "file: $j"
-              FS_CHECKSUM=`md5sum "${j}" | awk {'print $1'}`
-  #            echo "FS_CHECKSUM: $FS_CHECKSUM"
+              #echo "file: $j"
+              FILE_NAME="${j##*/}"
+              FILE_DIR="${j:0:${#j} - ${#FILE_NAME}}"
+              OVERRIDE_FILE="${FILE_DIR}${environment}/$FILE_NAME"
+              if [[ -f $OVERRIDE_FILE ]]
+              then
+                FS_CHECKSUM=`md5sum "${OVERRIDE_FILE}" | awk {'print $1'}`
+                #echo "OVERRIDE_FILE: ${OVERRIDE_FILE}"
+              else
+                FS_CHECKSUM=`md5sum "${j}" | awk {'print $1'}`
+              fi
+
+              #echo "FS_CHECKSUM: $FS_CHECKSUM"
               FS=`echo -e "${FS}\n$j--dbdeployer-md5sum--$FS_CHECKSUM"`
+
             done
           else
             FS=''

--- a/plugins/git/deployment_report.sh
+++ b/plugins/git/deployment_report.sh
@@ -16,15 +16,20 @@ then
     echo "WARNING: This branch is not current with master. Consider merging"
     echo "         master into your branch. Do you want to continue in the "
     echo "         current state?"
-    select yn in "Yes" "No"; do
-      case ${yn} in
-        Yes ) break;;
-        No ) exit;;
-      esac
-    done
-    echo
-    echo
-    echo
+    if [ "${confirm}" = 'true' ]
+    then
+      echo "Confirm flag is set, continuing automatically..."
+    else
+      select yn in "Yes" "No"; do
+        case ${yn} in
+          Yes ) break;;
+          No ) exit;;
+        esac
+      done
+      echo
+      echo
+      echo
+    fi
   fi
 fi
 

--- a/plugins/git/deployment_report.sh
+++ b/plugins/git/deployment_report.sh
@@ -118,21 +118,25 @@ deployment_report() {
               FILE_NAME="${j##*/}"
               FILE_DIR="${j:0:${#j} - ${#FILE_NAME}}"
               OVERRIDE_FILE="${FILE_DIR}${environment}/$FILE_NAME"
+              FILE_NOT_FOUND="false"
 
               if [[ -f $OVERRIDE_FILE ]]
               then
                 FS_CHECKSUM=`md5sum "${OVERRIDE_FILE}" | awk {'print $1'}`
                 #echo "OVERRIDE_FILE: ${OVERRIDE_FILE}"
-              else
+              elif [[ -f "${j}" ]]
+              then
                 FS_CHECKSUM=`md5sum "${j}" | awk {'print $1'}`
+              else
+                FILE_NOT_FOUND="true"
               fi
 
               #echo "FS_CHECKSUM: $FS_CHECKSUM"
-              FS=`echo -e "${FS}\n$j--dbdeployer-md5sum--$FS_CHECKSUM"`
-
+              if [[ "${FILE_NOT_FOUND}" = "false" ]]
+              then
+                FS=`echo -e "${FS}\n$j--dbdeployer-md5sum--$FS_CHECKSUM"`
+              fi
             done
-
-
           else
             FS=''
           fi

--- a/plugins/git/deployment_report.sh
+++ b/plugins/git/deployment_report.sh
@@ -8,7 +8,7 @@ current_branch="`git rev-parse --abbrev-ref --symbolic-full-name @{u}`"
 # alert if branch to compare is ahead of current branch
 if [ "${current_branch}" != "${branch_to_compare}" ]
 then
-  check_if_branch_current=`git rev-list --left-right --count ${branch_to_compare}...${current_branch} | awk {'print $2'}`
+  check_if_branch_current=`git rev-list --left-right --count ${branch_to_compare}...${current_branch} | awk {'print $1'}`
   #echo "check_if_branch_current: ${check_if_branch_current}"
   if [ $check_if_branch_current -ne 0 ]
   then

--- a/plugins/git/deployment_report.sh
+++ b/plugins/git/deployment_report.sh
@@ -79,23 +79,29 @@ deployment_report() {
             then
               FS_LIST=`eval "ls -o1 "${deploy_folder}"/*.sql | awk {'print ${deployment_report_argnum}'} | sort -rn | xargs"`
 
-              for j in ${FS_LIST}
-              do
-                # echo "file: $j"
-                FS_CHECKSUM=`md5sum "${j}" | awk {'print $1'}`
-                # echo "FS_CHECKSUM: $FS_CHECKSUM"
-                FS=`echo -e "${FS}\n$j--dbdeployer-md5sum--$FS_CHECKSUM"`
-              done
             else
               FS_LIST=`eval "git diff --name-only ${branch_to_compare} | grep \"^${dbname}/${i}/\" | grep '.sql' | xargs"`
-              for j in ${FS_LIST}
-              do
-                # echo "file: $j"
-                FS_CHECKSUM=`md5sum "${j}" | awk {'print $1'}`
-                # echo "FS_CHECKSUM: $FS_CHECKSUM"
-                FS=`echo -e "${FS}\n${db_basedir}/$j--dbdeployer-md5sum--$FS_CHECKSUM"`
-              done
             fi
+
+            for j in ${FS_LIST}
+            do
+              #echo "file: $j"
+              FILE_NAME="${j##*/}"
+              FILE_DIR="${j:0:${#j} - ${#FILE_NAME}}"
+              OVERRIDE_FILE="${FILE_DIR}${environment}/$FILE_NAME"
+
+              if [[ -f $OVERRIDE_FILE ]]
+              then
+                FS_CHECKSUM=`md5sum "${OVERRIDE_FILE}" | awk {'print $1'}`
+                #echo "OVERRIDE_FILE: ${OVERRIDE_FILE}"
+              else
+                FS_CHECKSUM=`md5sum "${j}" | awk {'print $1'}`
+              fi
+
+              #echo "FS_CHECKSUM: $FS_CHECKSUM"
+              FS=`echo -e "${FS}\n$j--dbdeployer-md5sum--$FS_CHECKSUM"`
+
+            done
 
 
           else


### PR DESCRIPTION
When written, I hadn't given though to the fact that the override files for environments could exist on auto deploy folders as well. This should solve a bug we were seeing in regular deploys and those with the git plugin when there is an override on a sproc/function/etc for auto deploy folders.

I also cleaned up some of the logic block to reduce duplicate code.

Added additional block to alert when behind master.