### PR TITLE
Fix --variables_to_replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2021-03-31 Release 1.5.10
+### Summary
+Bug Fix
+
+### Changes
+  - variables_to_replace did not pass through to sub calls when passed on cli
+
 ## 2020-06-25 Release 1.5.9
 ### Summary
 Security Fix

--- a/dbdeployer
+++ b/dbdeployer
@@ -157,7 +157,6 @@ do
     -o|--variables_to_replace)
       shift
       variables_to_replace="${1}"
-      variables_to_replace_cli="${1}"
       shift
       ;;
     -p|--port)

--- a/dbdeployer
+++ b/dbdeployer
@@ -157,6 +157,7 @@ do
     -o|--variables_to_replace)
       shift
       variables_to_replace="${1}"
+      variables_to_replace_cli="${1}"
       shift
       ;;
     -p|--port)

--- a/dbdeployer_release
+++ b/dbdeployer_release
@@ -1,1 +1,1 @@
-version=1.5.9
+version=1.5.10

--- a/functions/deployment_report.sh
+++ b/functions/deployment_report.sh
@@ -21,7 +21,7 @@ deployment_report() {
     do
       if ! [ -z "${x}" ]
       then
-        echo "${script_name} -f "${x}" -n "${db_destination_name}" ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${confirm_cli}" --variables_to_replace "$variables_to_replace_cli"
+        echo "${script_name} -f ${x} -n ${db_destination_name} -o '${variables_to_replace}' ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${confirm_cli}"
         let "pending_count++"
       fi
     done
@@ -81,7 +81,7 @@ deployment_report() {
             if ! [ -z "${x}" ]
             then
               auto_deploy_file=`echo ${x} | awk -F '--dbdeployer-md5sum--' {'print $1'}`
-              echo "${script_name} -f "${auto_deploy_file}" -c -n "${db_destination_name}" ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli}" --variables_to_replace "$variables_to_replace_cli"
+              echo "${script_name} -f ${auto_deploy_file} -c -n ${db_destination_name} -o '${variables_to_replace}' ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli}"
               let "pending_count++"
             fi
           done

--- a/functions/deployment_report.sh
+++ b/functions/deployment_report.sh
@@ -21,7 +21,7 @@ deployment_report() {
     do
       if ! [ -z "${x}" ]
       then
-        echo "${script_name} -f "${x}" -n "${db_destination_name}" ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${confirm_cli}"
+        echo "${script_name} -f "${x}" -n "${db_destination_name}" ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${confirm_cli}" --variables_to_replace "$variables_to_replace_cli"
         let "pending_count++"
       fi
     done
@@ -81,7 +81,7 @@ deployment_report() {
             if ! [ -z "${x}" ]
             then
               auto_deploy_file=`echo ${x} | awk -F '--dbdeployer-md5sum--' {'print $1'}`
-              echo "${script_name} -f "${auto_deploy_file}" -c -n "${db_destination_name}" ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli}"
+              echo "${script_name} -f "${auto_deploy_file}" -c -n "${db_destination_name}" ${run_as_cli} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli}" --variables_to_replace "$variables_to_replace_cli"
               let "pending_count++"
             fi
           done

--- a/functions/update_db_to_current.sh
+++ b/functions/update_db_to_current.sh
@@ -6,7 +6,8 @@ function update_db_to_current() {
 
   #echo "report_var executes: ${script_name} ${run_as_cli} -D ${db_basedir} -r -d \"${_dbname}\" -n \"${_db_destination_name}\" ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${module_list_cli} ${confirm_cli} | grep \"${script_name} -f\""
 
-  report_var=`${script_name} ${run_as_cli} -D ${db_basedir} -r -d "${_dbname}" -n "${_db_destination_name}" ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${module_list_cli} ${confirm_cli} --variables_to_replace "'${variables_to_replace_cli}'" | grep "${script_name} -f"`
+  report_var=`${script_name} ${run_as_cli} -D ${db_basedir} -r -d "${_dbname}" -n "${_db_destination_name}" -o ${variables_to_replace} ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${module_list_cli} ${confirm_cli} | grep "${script_name} -f"`
+
   local IFS=$'\n'
   for j in `echo -e "${report_var}"`
   do

--- a/functions/update_db_to_current.sh
+++ b/functions/update_db_to_current.sh
@@ -6,7 +6,7 @@ function update_db_to_current() {
 
   #echo "report_var executes: ${script_name} ${run_as_cli} -D ${db_basedir} -r -d \"${_dbname}\" -n \"${_db_destination_name}\" ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${module_list_cli} ${confirm_cli} | grep \"${script_name} -f\""
 
-  report_var=`${script_name} ${run_as_cli} -D ${db_basedir} -r -d "${_dbname}" -n "${_db_destination_name}" ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${module_list_cli} ${confirm_cli} | grep "${script_name} -f"`
+  report_var=`${script_name} ${run_as_cli} -D ${db_basedir} -r -d "${_dbname}" -n "${_db_destination_name}" ${environment_flag} ${server_cli} ${port_cli} ${dbuser_cli} ${password_cli} ${skip_cli} ${dbtype_cli} ${module_list_cli} ${confirm_cli} --variables_to_replace "'${variables_to_replace_cli}'" | grep "${script_name} -f"`
   local IFS=$'\n'
   for j in `echo -e "${report_var}"`
   do


### PR DESCRIPTION
When passing --variables_to_replace, the value was not being passed into the nested calls which means they were effectively not being applied at all. Presumably all current usage of dbdeployer is passing variables_to_replace in via config files instead of command-line arguments, but my needs don't easily allow for configuration via file